### PR TITLE
Add and implement code of conduct page

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -42,6 +42,9 @@ import MemberListPage, {
   MemberListPageOptions,
 } from "./src/components/communities/MemberListPage";
 import { GlobalServiceProvider } from "./src/contexts";
+import CodeOfConductPage, {
+  CodeOfConductPageOptions,
+} from "./src/components/communities/CodeOfConductPage";
 
 const fonts = {
   "SFProDisplay-Bold": require("./assets/fonts/SF-Pro-Display-Bold.otf"),
@@ -96,6 +99,11 @@ export default function App() {
             name="BannedUsers"
             component={BannedUsersPage}
             options={BannedUsersPageOptions}
+          />
+          <Stack.Screen
+            name="CodeOfConduct"
+            component={CodeOfConductPage}
+            options={CodeOfConductPageOptions}
           />
           <Stack.Screen
             name="CommunityAdministration"

--- a/src/components/communities/CodeOfConductPage.tsx
+++ b/src/components/communities/CodeOfConductPage.tsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useState } from "react";
+import { StyleSheet } from "react-native";
+
+import {
+  getCommunity,
+  loadCommunity,
+  useCommunity,
+} from "../../contexts/communityContext";
+import { useToken } from "../../contexts/tokenContext";
+import {
+  CodeOfConductPageNavigationProp,
+  CodeOfConductPageRouteProp,
+} from "../../routes";
+import Box from "../themed/Box";
+import Text from "../themed/Text";
+
+// React Navigation Types and Page Options
+
+type CodeOfConductPageProps = {
+  navigation: CodeOfConductPageNavigationProp;
+  route: CodeOfConductPageRouteProp;
+};
+
+export const CodeOfConductPageOptions = {
+  title: "Code Of Conduct",
+};
+
+// Page Styles
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    flexDirection: "column",
+    justifyContent: "flex-start",
+  },
+});
+
+// Page Definition
+
+export default function BannedUsersPage({ route }: CodeOfConductPageProps) {
+  // Load Community Dependencies
+  const [communityState, communityDispatch] = useCommunity();
+  const [tokenState, tokenDispatch] = useToken();
+
+  // Utilize community data
+  const [codeOfConduct, setCodeOfConduct] = useState("");
+
+  useEffect(() => {
+    // automatically queue a data update
+    loadCommunity(
+      communityDispatch,
+      tokenDispatch,
+      tokenState.refreshToken,
+      route.params.name
+    );
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    const community = getCommunity(communityState, route.params.name);
+    setCodeOfConduct(community.codeofconduct);
+  }, [communityState, route.params.name]);
+
+  return (
+    <Box backgroundColor="mainBackground" style={styles.root}>
+      <Text variant="header" style={{ textAlign: "center" }} m="sm">
+        {route.params.name} Code of Conduct:
+      </Text>
+      <Text variant="body" m="sm">
+        {codeOfConduct}
+      </Text>
+    </Box>
+  );
+}

--- a/src/components/communities/DevelopmentLinksPage.tsx
+++ b/src/components/communities/DevelopmentLinksPage.tsx
@@ -84,6 +84,16 @@ export default function DevelopmentLinksPage({
       </Box>
       <Box style={styles.btnbox}>
         <Button
+          title="Code of Conduct"
+          onPress={() =>
+            navigation.push("CodeOfConduct", {
+              name: "Johnsons",
+            })
+          }
+        />
+      </Box>
+      <Box style={styles.btnbox}>
+        <Button
           title="Create Community"
           onPress={() => navigation.push("CreateCommunity")}
         />

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -16,6 +16,7 @@ type RootStackParamList = {
   UserSettings: undefined;
   MemberList: { name: string };
   DevelopmentLinks: undefined;
+  CodeOfConduct: { name: string };
 };
 
 //TODO remove for release
@@ -135,6 +136,17 @@ export type MemberListPageRouteProp = RouteProp<
 export type MemberListPageNavigationProp = StackNavigationProp<
   RootStackParamList,
   "MemberList"
+>;
+
+// Code of Conduct Page Types
+export type CodeOfConductPageRouteProp = RouteProp<
+  RootStackParamList,
+  "CodeOfConduct"
+>;
+
+export type CodeOfConductPageNavigationProp = StackNavigationProp<
+  RootStackParamList,
+  "CodeOfConduct"
 >;
 
 // Community Administration Page Types


### PR DESCRIPTION
This was marked as not done on the sprint retro despite being a quick story to implement. I have done the UI and integration so we don't lose points on this. 