### PR TITLE
Add MeetupDetails page with dummy data

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -45,6 +45,9 @@ import { GlobalServiceProvider } from "./src/contexts";
 import CodeOfConductPage, {
   CodeOfConductPageOptions,
 } from "./src/components/communities/CodeOfConductPage";
+import MeetupDetailsPage, {
+  MeetupDetailsPageOptions,
+} from "./src/components/meetups/MeetupDetailsPage";
 
 const fonts = {
   "SFProDisplay-Bold": require("./assets/fonts/SF-Pro-Display-Bold.otf"),
@@ -134,6 +137,11 @@ export default function App() {
             name="LeaveCommunity"
             component={LeaveCommunityPage}
             options={LeaveCommunityPageOptions}
+          />
+          <Stack.Screen
+            name="MeetupDetails"
+            component={MeetupDetailsPage}
+            options={MeetupDetailsPageOptions}
           />
         </Stack.Navigator>
       </GlobalServiceProvider>

--- a/src/components/communities/DevelopmentLinksPage.tsx
+++ b/src/components/communities/DevelopmentLinksPage.tsx
@@ -124,6 +124,14 @@ export default function DevelopmentLinksPage({
           onPress={() => navigation.push("ViewProfile")}
         />
       </Box>
+      <Box style={styles.btnbox}>
+        <Button
+          title="Meetup Details"
+          onPress={() =>
+            navigation.push("MeetupDetails", { meetingID: "ABCDEFGH" })
+          }
+        />
+      </Box>
     </Box>
   );
 }

--- a/src/components/meetups/MeetupDetailsPage.tsx
+++ b/src/components/meetups/MeetupDetailsPage.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { FlatList, StyleSheet } from "react-native";
+
+import {
+  MeetupDetailsPageNavigationProp,
+  MeetupDetailsPageRouteProp,
+} from "../../routes";
+import Box from "../themed/Box";
+import Text from "../themed/Text";
+import ThemedCard from "../themed/ThemedCard";
+
+type MeetupDetailsPageProps = {
+  route: MeetupDetailsPageRouteProp;
+  navigation: MeetupDetailsPageNavigationProp;
+};
+
+export const MeetupDetailsPageOptions = {
+  title: "Meetup Details",
+};
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    flexDirection: "column",
+    alignItems: "center",
+  },
+});
+
+export default function MeetupDetailsPage({ route }: MeetupDetailsPageProps) {
+  // TODO: Load in real data of the passed in meeting
+  const { meetingID } = route.params;
+  const meetupTime = "3:00 PM";
+  const meetupDuration = 25;
+  const meetupLocation = "Online";
+  const meetupParticipants = ["John Smith", "Bob Smith", "Alice Smith"];
+
+  // TODO: Make this prettier
+  const renderParticipant = ({ item }: { item: string }) => (
+    <Text variant="body">{item}</Text>
+  );
+
+  return (
+    <Box backgroundColor="mainBackground" style={styles.root}>
+      <ThemedCard>
+        <Text variant="header">Meetup Details</Text>
+        <Text variant="subheader">Starts at {meetupTime}</Text>
+        <Text variant="subheader">Lasts {meetupDuration} minutes</Text>
+        <Text variant="subheader">{meetupLocation}</Text>
+        <Text>{meetingID}</Text>
+      </ThemedCard>
+      <ThemedCard>
+        <Text variant="subheader">Participants</Text>
+        <FlatList
+          data={meetupParticipants}
+          keyExtractor={(item, index) => item + index.toString()}
+          renderItem={renderParticipant}
+        />
+      </ThemedCard>
+    </Box>
+  );
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -17,6 +17,7 @@ type RootStackParamList = {
   MemberList: { name: string };
   DevelopmentLinks: undefined;
   CodeOfConduct: { name: string };
+  MeetupDetails: { meetingID: string };
 };
 
 //TODO remove for release
@@ -167,6 +168,17 @@ export type UserSettingsPageRouteProp = RouteProp<
 >;
 
 export type UserSettingsPageNavigationProp = StackNavigationProp<
+  RootStackParamList,
+  "UserSettings"
+>;
+
+// Meetup Details Page Types
+export type MeetupDetailsPageRouteProp = RouteProp<
+  RootStackParamList,
+  "MeetupDetails"
+>;
+
+export type MeetupDetailsPageNavigationProp = StackNavigationProp<
   RootStackParamList,
   "UserSettings"
 >;


### PR DESCRIPTION
Simple PR that creates a new screen for meeting details with dummy data. I realize that I can make a reusable component to show the general meeting data so I will create that once the codebase is up to date with my other merges. Integration coming later this week