### PR TITLE
Create MeetupRatingPage and dummy data

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -45,6 +45,9 @@ import { GlobalServiceProvider } from "./src/contexts";
 import CodeOfConductPage, {
   CodeOfConductPageOptions,
 } from "./src/components/communities/CodeOfConductPage";
+import MeetupRatingPage, {
+  MeetupRatingPageOptions,
+} from "./src/components/meetups/MeetupRatingPage";
 
 const fonts = {
   "SFProDisplay-Bold": require("./assets/fonts/SF-Pro-Display-Bold.otf"),
@@ -134,6 +137,11 @@ export default function App() {
             name="LeaveCommunity"
             component={LeaveCommunityPage}
             options={LeaveCommunityPageOptions}
+          />
+          <Stack.Screen
+            name="MeetupRating"
+            component={MeetupRatingPage}
+            options={MeetupRatingPageOptions}
           />
         </Stack.Navigator>
       </GlobalServiceProvider>

--- a/src/components/communities/DevelopmentLinksPage.tsx
+++ b/src/components/communities/DevelopmentLinksPage.tsx
@@ -124,6 +124,14 @@ export default function DevelopmentLinksPage({
           onPress={() => navigation.push("ViewProfile")}
         />
       </Box>
+      <Box style={styles.btnbox}>
+        <Button
+          title="Meetup Rating"
+          onPress={() =>
+            navigation.push("MeetupRating", { meetupID: "ABCDEFGH" })
+          }
+        />
+      </Box>
     </Box>
   );
 }

--- a/src/components/meetups/MeetupRatingPage.tsx
+++ b/src/components/meetups/MeetupRatingPage.tsx
@@ -1,0 +1,89 @@
+import React, { useState } from "react";
+import { FlatList, StyleSheet } from "react-native";
+import { AirbnbRating } from "react-native-elements";
+import { useTheme } from "@shopify/restyle";
+
+import {
+  MeetupRatingPageNavigationProp,
+  MeetupRatingPageRouteProp,
+} from "../../routes";
+import Box from "../themed/Box";
+import Text from "../themed/Text";
+import ThemedCard from "../themed/ThemedCard";
+import ThemedButton from "../themed/ThemedButton";
+import { Theme } from "../../theme";
+
+type MeetupRatingPageProps = {
+  route: MeetupRatingPageRouteProp;
+  navigation: MeetupRatingPageNavigationProp;
+};
+
+export const MeetupRatingPageOptions = {
+  title: "Meetup Rating",
+};
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    flexDirection: "column",
+    alignItems: "center",
+  },
+});
+
+export default function MeetupRatingPage({
+  navigation,
+  route,
+}: MeetupRatingPageProps) {
+  // TODO: Load in real data of the passed in meetingMeetupRatingPageProps
+  const { meetupID } = route.params;
+  const meetupTime = "3:00 PM";
+  const meetupDuration = 25;
+  const meetupLocation = "Online";
+  const meetupParticipants = ["John Smith", "Bob Smith", "Alice Smith"];
+
+  // TODO: Make this prettier
+  const renderParticipant = ({ item }: { item: string }) => (
+    <Text variant="body">{item}</Text>
+  );
+
+  const [rating, setRating] = useState(3);
+  const submitRating = () => {
+    //   TODO: Integrate rating with the backend
+    console.log(`Rated meetup ${meetupID} as ${rating}/5`);
+    navigation.goBack();
+  };
+
+  const theme = useTheme<Theme>();
+
+  return (
+    <Box backgroundColor="mainBackground" style={styles.root}>
+      <ThemedCard>
+        <Text variant="header">Meetup Details</Text>
+        <Text variant="subheader">Starts at {meetupTime}</Text>
+        <Text variant="subheader">Lasts {meetupDuration} minutes</Text>
+        <Text variant="subheader">{meetupLocation}</Text>
+        <Text>{meetupID}</Text>
+      </ThemedCard>
+      <ThemedCard>
+        <Text variant="subheader">Participants</Text>
+        <FlatList
+          data={meetupParticipants}
+          keyExtractor={(item, index) => item + index.toString()}
+          renderItem={renderParticipant}
+        />
+      </ThemedCard>
+      <ThemedCard>
+        <Text variant="body">How would you rate your experience?</Text>
+        <AirbnbRating /* @ts-ignore:disable-next-line */
+          reviewColor={theme.colors.iconPrimary}
+          defaultRating={rating}
+          selectedColor={theme.colors.iconPrimary}
+          onFinishRating={setRating}
+        />
+        <Box mt="md">
+          <ThemedButton title="Submit Rating" onPress={submitRating} />
+        </Box>
+      </ThemedCard>
+    </Box>
+  );
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -17,6 +17,7 @@ type RootStackParamList = {
   MemberList: { name: string };
   DevelopmentLinks: undefined;
   CodeOfConduct: { name: string };
+  MeetupRating: { meetupID: string };
 };
 
 //TODO remove for release
@@ -169,4 +170,15 @@ export type UserSettingsPageRouteProp = RouteProp<
 export type UserSettingsPageNavigationProp = StackNavigationProp<
   RootStackParamList,
   "UserSettings"
+>;
+
+// User Settings Page Types
+export type MeetupRatingPageRouteProp = RouteProp<
+  RootStackParamList,
+  "MeetupRating"
+>;
+
+export type MeetupRatingPageNavigationProp = StackNavigationProp<
+  RootStackParamList,
+  "MeetupRating"
 >;


### PR DESCRIPTION
Final PR for the night ;). Added a meetup rating page to allow the user to rate the meeting 1 to 5. Not sure if we want to include text feedback but it would be easy to add in if necessary. I had to a a ts-ignore rule since the typing of the props for the rating components doesn't seem to be up to date